### PR TITLE
カラーパレットの反転とフォントをHelveticaに変更

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -12,16 +12,16 @@
 
 :root {
   /* colors */
-  --background-color: white;
-  --light-color: #f8f8f8;
-  --dark-color: #505050;
-  --text-color: #131313;
-  --link-color: #3b63fb;
-  --link-hover-color: #1d3ecf;
+  --background-color: black;
+  --light-color: #070707;
+  --dark-color: #afafaf;
+  --text-color: #ececec;
+  --link-color: #c49c04;
+  --link-hover-color: #e2c1f0;
 
   /* fonts */
-  --body-font-family: roboto, roboto-fallback, sans-serif;
-  --heading-font-family: roboto-condensed, roboto-condensed-fallback, sans-serif;
+  --body-font-family: helvetica, arial, sans-serif;
+  --heading-font-family: helvetica, arial, sans-serif;
 
   /* body sizes */
   --body-font-size-m: 22px;
@@ -41,17 +41,6 @@
 }
 
 /* fallback fonts */
-@font-face {
-  font-family: roboto-condensed-fallback;
-  size-adjust: 88.82%;
-  src: local('Arial');
-}
-
-@font-face {
-  font-family: roboto-fallback;
-  size-adjust: 99.529%;
-  src: local('Arial');
-}
 
 @media (width >= 900px) {
   :root {


### PR DESCRIPTION
## 変更内容

### カラーパレットの反転
- `--background-color`: white → black
- `--light-color`: #f8f8f8 → #070707
- `--dark-color`: #505050 → #afafaf
- `--text-color`: #131313 → #ececec
- `--link-color`: #3b63fb → #c49c04
- `--link-hover-color`: #1d3ecf → #e2c1f0

### フォントファミリーの変更
- `--body-font-family`: roboto → helvetica
- `--heading-font-family`: roboto-condensed → helvetica
- 不要なRoboto用フォールバックフォント設定を削除

## 効果
- サイト全体がダークテーマになります
- フォントがHelveticaに統一されます
- よりクリーンなフォント設定になります

## テスト
- [ ] カラーの反転が正しく適用されているか
- [ ] Helveticaフォントが正しく表示されているか
- [ ] レスポンシブデザインが維持されているか

## URL for testing:

- https://feature-color-font-updates--masukawa-eds--mastin0413.aem.page/